### PR TITLE
fixed ProxyDb references.

### DIFF
--- a/proxyDb/index.js
+++ b/proxyDb/index.js
@@ -4,7 +4,6 @@ const DEFAULT_STRATEGY = 'mongoose';
 
 class ProxyDb {
 	constructor(strategyName, config={}) {
-		this.managers = [];
 
 		if(typeof config === 'string') config = {strategyPath: config};
 
@@ -25,7 +24,7 @@ class ProxyDb {
 		}
 
 		const manager = new Manager(strategyName, config);
-		this.managers.push(manager);
+		ProxyDb.managers.push(manager);
 		return manager;
 	}
 
@@ -43,13 +42,17 @@ class ProxyDb {
 	}
 	
 	static get connections() {
-		return ProxyDb.managers.map(manager=> {
+		return this.managers.map(manager=> {
 			return manager.connections
 		})
 		
 	}
-}
 
+	static get db() {
+		return this.managers[0]
+	}
+}
+ProxyDb.managers = [];
 ProxyDb.strategies = {};
 
 

--- a/test/full/proxyDb.spec.js
+++ b/test/full/proxyDb.spec.js
@@ -2,24 +2,26 @@ const expect = require('chai').expect;
 const assert = require('chai').assert;
 
 const ProxyDb = require('../../index');
-
+  
 describe('ProxyDb', function() {
+  let manager1;
+  let manager2;
   it('is a constructor that can create Manager instances', function() {
     // Default strategy: mongoose.
-    const manager = new ProxyDb('mongoose');
+    manager1 = new ProxyDb('mongoose');
     
-    expect(manager).to.have.property('ProxyDb', ProxyDb);
-    expect(manager).to.have.property('strategy');
-    expect(manager).to.have.property('_models');
+    expect(manager1).to.have.property('ProxyDb', ProxyDb);
+    expect(manager1).to.have.property('strategy');
+    expect(manager1).to.have.property('_models');
   });
 
   it('can manually set the path of a Strategy during construction', function() {
     // Default strategy: mongoose.
-    const manager = new ProxyDb('mongoose', '../strategies/mongoose-strategy');
+    manager2 = new ProxyDb('mongoose', '../strategies/mongoose-strategy');
 
-    expect(manager).to.have.property('ProxyDb', ProxyDb);
-    expect(manager).to.have.property('strategy');
-    expect(manager).to.have.property('_models');
+    expect(manager2).to.have.property('ProxyDb', ProxyDb);
+    expect(manager2).to.have.property('strategy');
+    expect(manager2).to.have.property('_models');
   });
 
   it('can register a new strategy without construction', function() {
@@ -28,8 +30,14 @@ describe('ProxyDb', function() {
     MockStrategy.dbModel = class MockDbModel {};
     ProxyDb.addStrategy('MockStrategy', MockStrategy);
 
-
     expect(ProxyDb).to.have.deep.property('strategies.MockStrategy', MockStrategy);
+  });
+
+  it('can access primary manager with .db', function() {
+    const pdb = require('../../index');
+    expect(pdb.db).to.equal(manager1)
+    expect(pdb.managers[0]).to.equal(manager1)
+    expect(pdb.db).to.not.equal(manager2)
   });
   
   


### PR DESCRIPTION
Can now access primary manager with `require('proxydb').db`
